### PR TITLE
#7 - trailing comma in a properties list shouldn't lead to validation errors

### DIFF
--- a/pkg/emd/parseCommand.go
+++ b/pkg/emd/parseCommand.go
@@ -16,6 +16,7 @@ func parseCommand(emdInput string, lineItems []Item) []Item {
 			var parameters []Parameter
 			first := command[0]
 			propertiesList := first[2]
+			propertiesList = strings.Trim(propertiesList, ",")
 			inputProperties := strings.Split(propertiesList, ",")
 			for _, inputParameter := range inputProperties {
 				var parsedParameter = Parameter{Name: strings.Trim(inputParameter, " ")}

--- a/pkg/emd/parseCommand.go
+++ b/pkg/emd/parseCommand.go
@@ -16,7 +16,7 @@ func parseCommand(emdInput string, lineItems []Item) []Item {
 			var parameters []Parameter
 			first := command[0]
 			propertiesList := first[2]
-			propertiesList = strings.Trim(propertiesList, ",")
+			propertiesList = strings.Trim(propertiesList, ", ")
 			inputProperties := strings.Split(propertiesList, ",")
 			for _, inputParameter := range inputProperties {
 				var parsedParameter = Parameter{Name: strings.Trim(inputParameter, " ")}

--- a/pkg/emd/parseDocument.go
+++ b/pkg/emd/parseDocument.go
@@ -16,6 +16,7 @@ func parseDocument(emdInput string, lineItems []Item) []Item {
 			var properties []Property
 			first := document[0]
 			propertiesList := first[2]
+			propertiesList = strings.Trim(propertiesList, ",")
 			inputProperties := strings.Split(propertiesList, ",")
 			for _, inputParameter := range inputProperties {
 				if inputParameter != "" {

--- a/pkg/emd/parseDocument.go
+++ b/pkg/emd/parseDocument.go
@@ -16,7 +16,7 @@ func parseDocument(emdInput string, lineItems []Item) []Item {
 			var properties []Property
 			first := document[0]
 			propertiesList := first[2]
-			propertiesList = strings.Trim(propertiesList, ",")
+			propertiesList = strings.Trim(propertiesList, ", ")
 			inputProperties := strings.Split(propertiesList, ",")
 			for _, inputParameter := range inputProperties {
 				if inputParameter != "" {

--- a/pkg/emd/parseEvent.go
+++ b/pkg/emd/parseEvent.go
@@ -16,7 +16,7 @@ func parseEvent(emdInput string, lineItems []Item) []Item {
 			var properties []Property
 			first := event[0]
 			propertiesList := first[2]
-			propertiesList = strings.Trim(propertiesList, ",")
+			propertiesList = strings.Trim(propertiesList, ", ")
 			inputProperties := strings.Split(propertiesList, ",")
 			for _, inputProperty := range inputProperties {
 				var parsedProperty = Property{Name: strings.Trim(inputProperty, " ")}

--- a/pkg/emd/parseEvent.go
+++ b/pkg/emd/parseEvent.go
@@ -16,6 +16,7 @@ func parseEvent(emdInput string, lineItems []Item) []Item {
 			var properties []Property
 			first := event[0]
 			propertiesList := first[2]
+			propertiesList = strings.Trim(propertiesList, ",")
 			inputProperties := strings.Split(propertiesList, ",")
 			for _, inputProperty := range inputProperties {
 				var parsedProperty = Property{Name: strings.Trim(inputProperty, " ")}


### PR DESCRIPTION
Trimming commas around the three lists of properties does the trick.