### PR TITLE
Issue 6: No validation error on trailing slashes on event lines without properties

### DIFF
--- a/pkg/emd/parseEvent.go
+++ b/pkg/emd/parseEvent.go
@@ -17,13 +17,17 @@ func parseEvent(emdInput string, lineItems []Item) []Item {
 			first := event[0]
 			propertiesList := first[2]
 			propertiesList = strings.Trim(propertiesList, ", ")
-			inputProperties := strings.Split(propertiesList, ",")
-			for _, inputProperty := range inputProperties {
-				var parsedProperty = Property{Name: strings.Trim(inputProperty, " ")}
-				properties = append(properties, parsedProperty)
+			if len(propertiesList) > 0 {
+				inputProperties := strings.Split(propertiesList, ",")
+				for _, inputProperty := range inputProperties {
+					var parsedProperty = Property{Name: strings.Trim(inputProperty, " ")}
+					properties = append(properties, parsedProperty)
+				}
+				lineItems = append(lineItems, Event{Name: strings.Trim(event[0][1], " "), Properties: properties})
+			} else {
+				lineItems = append(lineItems, Event{Name: strings.Trim(event[0][1], " ")})
 			}
 
-			lineItems = append(lineItems, Event{Name: strings.Trim(event[0][1], " "), Properties: properties})
 		}
 	} else {
 		lineItems = append(lineItems, Event{Name: strings.Trim(emdInput, " ")})

--- a/pkg/emd/parseEvent_test.go
+++ b/pkg/emd/parseEvent_test.go
@@ -121,6 +121,9 @@ func TestShouldGetEventWithoutPropertiesWithTrailingSlashes(t *testing.T) {
 		if result.Lines[0].(emd.Event).Name != "User Registered" {
 			t.Error("Unexpected Event.Name")
 		}
+		if len(result.Lines[0].(emd.Event).Properties) != 0 {
+			t.Error("Unexpected Event.Properties.")
+		}
 	default:
 		t.Error("expected event")
 	}


### PR DESCRIPTION
This is a PR for issue 6: https://github.com/Adaptech/les/issues/6

### Description:
Create an event without properties if the event line does not have any properties in the EMD